### PR TITLE
Now handling additional NSURLError case

### DIFF
--- a/Sources/Network/Http/UrlSessionHttp.swift
+++ b/Sources/Network/Http/UrlSessionHttp.swift
@@ -159,7 +159,7 @@ open class UrlSessionHttp: Http {
 
         switch urlError.code {
             case NSURLErrorTimedOut, NSURLErrorCannotFindHost, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
-                    NSURLErrorDNSLookupFailed, NSURLErrorNotConnectedToInternet:
+                    NSURLErrorDNSLookupFailed, NSURLErrorNotConnectedToInternet, NSURLErrorDataNotAllowed:
                 return HttpError.unreachable(error)
             default:
                 return HttpError.error(error)


### PR DESCRIPTION
When cellular connection is unavailable and Wi-Fi is turned off, `NSURLErrorDataNotAllowed` error is returned. It should also be converted to `HttpError.unreachable`.