### PR TITLE
NetworkImageView - removed dependency on bounds when setting image by url

### DIFF
--- a/Sources/UI/NetworkImageView.swift
+++ b/Sources/UI/NetworkImageView.swift
@@ -19,17 +19,9 @@ open class NetworkImageView: UIImageView {
 
     open var imageUrl: URL? {
         didSet {
-            if oldValue != imageUrl {
+			if oldValue != imageUrl || image == nil {
                 update()
             }
-        }
-    }
-
-    override open func layoutSubviews() {
-        super.layoutSubviews()
-
-        if !loading && image == nil {
-            update()
         }
     }
 
@@ -38,7 +30,6 @@ open class NetworkImageView: UIImageView {
     private func update() {
         image = placeholder
 
-        guard bounds.width > 0.1 && bounds.height > 0.1 else { return }
         guard let imageLoader = imageLoader, let imageUrl = imageUrl else { return }
 
         loading = true


### PR DESCRIPTION
Баг заключался в следующем.

Если задать url изображения сразу после создания вью, фактическая загрузка изображения откладывалась до лэйаута. Однако при лэйауте проверялось условие что изображение еще не установлено, в то время как при задании url уже было установлено изображение-плейсхолдер. Налицо противоречие. Особенно хорошо эффект наблюдается в переиспользуемых ячейках таблицы - иногда изображение теряется, отображается только плейсхолдер.

Мне не удалось найти резонов, чтобы откладывать загрузку изображения до лэйаута, более того, мне это кажется ненужным увеличением задержки, поэтому я вовсе убрал проверку размера. Но не исключаю что резоны могут быть, поэтому лишь предлагаю рассмотреть насколько приведенный фикс уместен.